### PR TITLE
simplify context type arguments

### DIFF
--- a/src/types.d.ts
+++ b/src/types.d.ts
@@ -6,17 +6,17 @@ type SpecialisedVisitors<T extends BaseNode, U> = {
 	[K in T['type']]?: Visitor<NodeOf<K, T>, U, T>;
 };
 
-export type Visitor<T, U, V> = (node: T, context: Context<T, U, V>) => V | void;
+export type Visitor<T, U, V> = (node: T, context: Context<V, U>) => V | void;
 
 export type Visitors<T extends BaseNode, U> = T['type'] extends '_'
 	? never
 	: SpecialisedVisitors<T, U> & { _?: Visitor<T, U, T> };
 
-export interface Context<T, U, V> {
-	path: V[];
+export interface Context<T, U> {
+	path: T[];
 	state: U;
 	next: (state: U) => void;
 	skip: () => void;
 	stop: () => void;
-	transform: (node: V, state?: U) => V;
+	transform: (node: T, state?: U) => T;
 }

--- a/src/walk.js
+++ b/src/walk.js
@@ -31,7 +31,7 @@ export function walk(node, state, visitors) {
 		/** @type {Record<string, any>} */
 		const mutations = {};
 
-		/** @type {import('./types').Context<T, U, T>} */
+		/** @type {import('./types').Context<T, U>} */
 		const context = {
 			path,
 			state,


### PR DESCRIPTION
no need to pass the specific node type, it's not used