### PR TITLE
rename transform to visit

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,13 +64,13 @@ const transformed = walk(program as Node, state, {
       };
     }
   },
-  IfStatement(node, { transform }) {
+  IfStatement(node, { visit }) {
     // normally, returning a value will halt
     // traversal into child nodes. you can
     // transform children with the current
-    // visitors using `transform(node, state?)`
+    // visitors using `visit(node, state?)`
     if (node.test.type === 'Literal' && node.test.value === true) {
-      return transform(node.consequent);
+      return visit(node.consequent);
     }
   }
 });
@@ -127,11 +127,11 @@ walk(node, state, visitors);
 Each visitor receives a second argument, `context`, which is an object with the following properties and methods:
 
 - `path: Node[]` — an array of parent nodes. For example, to get the root node you would do `path.at(0)`; to get the current node's immediate parent you would do `path.at(-1)`
-- `state: State` — an object of the same type as the second argument to `walk`. Visitors can pass new state objects to their children with `next(childState)` or `transform(node, childState)`
+- `state: State` — an object of the same type as the second argument to `walk`. Visitors can pass new state objects to their children with `next(childState)` or `visit(node, childState)`
 - `next(state: State): void` — a function that allows you to control when child nodes are visited, and which state they are visited with. It can be called zero or one times — if zero, it will be called automatically once the current node has been visited
 - `skip(): void` — prevents children from being visited
 - `stop(): void` — prevents any subsequent traversal
-- `transform(node: Node, state?: State): Node` — returns the result of visiting `node` with the current set of visitors. If no `state` is provided, children will inherit the current state
+- `visit(node: Node, state?: State): Node` — returns the result of visiting `node` with the current set of visitors. If no `state` is provided, children will inherit the current state
 
 ## Immutability
 

--- a/src/types.d.ts
+++ b/src/types.d.ts
@@ -18,5 +18,5 @@ export interface Context<T, U> {
 	next: (state: U) => void;
 	skip: () => void;
 	stop: () => void;
-	transform: (node: T, state?: U) => T;
+	visit: (node: T, state?: U) => T;
 }

--- a/src/walk.js
+++ b/src/walk.js
@@ -84,7 +84,7 @@ export function walk(node, state, visitors) {
 			stop: () => {
 				stopped = skipped = true;
 			},
-			transform: (node, new_state = state) => {
+			visit: (node, new_state = state) => {
 				return visit(node, path, new_state) ?? node;
 			}
 		};

--- a/test/transformation.js
+++ b/test/transformation.js
@@ -12,10 +12,10 @@ test('transforms a tree', () => {
 
 	const transformed = /** @type {import('./types').TransformedRoot} */ (
 		walk(/** @type {import('./types').TestNode} */ (tree), null, {
-			Root: (node, { transform }) => {
+			Root: (node, { visit }) => {
 				return {
 					type: 'TransformedRoot',
-					elements: node.children.map((child) => transform(child))
+					elements: node.children.map((child) => visit(child))
 				};
 			},
 			A: (node) => {


### PR DESCRIPTION
this better reflects the fact that you can visit child nodes that _aren't_ transformed (since you might want to just populate something on `state`)