### PR TITLE
skip children when visiting

### DIFF
--- a/src/walk.js
+++ b/src/walk.js
@@ -85,6 +85,7 @@ export function walk(node, state, visitors) {
 				stopped = skipped = true;
 			},
 			visit: (node, new_state = state) => {
+				visited_next = true;
 				return visit(node, path, new_state) ?? node;
 			}
 		};


### PR DESCRIPTION
this might turn out to be too opinionated, but: when calling `visit(...)` inside a visitor, you almost certainly don't want to also visit child nodes automatically just because you didn't also call `next(...)`. 

the 'correct' way to handle this would be to require people to always call `next(...)`, that way there's no ambiguity. but that might be too annoying. we'll see