### PR TITLE
forward state correctly

### DIFF
--- a/src/walk.js
+++ b/src/walk.js
@@ -28,6 +28,10 @@ export function walk(node, state, visitors) {
 		let visited_next = false;
 		let skipped = false;
 
+		/** @type {T | void} */
+		let result;
+		let next_state = state;
+
 		/** @type {Record<string, any>} */
 		const mutations = {};
 
@@ -84,7 +88,7 @@ export function walk(node, state, visitors) {
 			stop: () => {
 				stopped = skipped = true;
 			},
-			visit: (node, new_state = state) => {
+			visit: (node, new_state = next_state) => {
 				visited_next = true;
 				return visit(node, path, new_state) ?? node;
 			}
@@ -93,9 +97,6 @@ export function walk(node, state, visitors) {
 		let visitor = /** @type {import('./types').Visitor<T, U, T>} */ (
 			visitors[/** @type {T['type']} */ (node.type)] ?? default_visitor
 		);
-
-		/** @type {T | void} */
-		let result;
 
 		if (universal) {
 			let visited_next = false;
@@ -108,6 +109,7 @@ export function walk(node, state, visitors) {
 				/** @param {U} state */
 				next: (state) => {
 					visited_next = true;
+					next_state = state;
 
 					inner_result = visitor(node, {
 						...context,
@@ -130,7 +132,7 @@ export function walk(node, state, visitors) {
 
 		if (!result) {
 			if (!visited_next && !skipped) {
-				context.next(state);
+				context.next(next_state);
 			}
 
 			if (Object.keys(mutations).length > 0) {

--- a/test/traversal.js
+++ b/test/traversal.js
@@ -91,3 +91,49 @@ test('visits all nodes with _', () => {
 		'0 1 leave Root'
 	]);
 });
+
+test('state is passed to children of specialized visitor when using universal visitor', () => {
+	/** @type {import('./types').TestNode} */
+	const tree = {
+		type: 'Root',
+		children: [{ type: 'A' }, { type: 'B' }, { type: 'C' }]
+	};
+
+	const state = {
+		universal: false
+	};
+
+	/** @type {string[]} */
+	const log = [];
+
+	walk(/** @type {import('./types').TestNode} */ (tree), state, {
+		_(node, { next }) {
+			if (node.type === 'Root') {
+				next({ universal: true });
+			}
+		},
+		Root(node, { state, visit }) {
+			log.push(`visited ${node.type} ${state.universal}`);
+
+			for (const child of node.children) {
+				visit(child);
+			}
+		},
+		A(node, { state, visit }) {
+			log.push(`visited ${node.type} ${state.universal}`);
+		},
+		B(node, { state, visit }) {
+			log.push(`visited ${node.type} ${state.universal}`);
+		},
+		C(node, { state, visit }) {
+			log.push(`visited ${node.type} ${state.universal}`);
+		}
+	});
+
+	expect(log).toEqual([
+		'visited Root true',
+		'visited A true',
+		'visited B true',
+		'visited C true'
+	]);
+});


### PR DESCRIPTION
At present, if a universal `_` visitor calls `next(state)`, the `state` won't be respected when we visit children from the specialised visitor. This fixes it