### PR TITLE
fix: prevent false-positive mutations

### DIFF
--- a/src/walk.js
+++ b/src/walk.js
@@ -22,8 +22,9 @@ export function walk(node, state, visitors) {
 	 * @returns {T | undefined}
 	 */
 	function visit(node, path, state) {
-		if (stopped) return node;
-		if (!node.type) return node;
+		// Don't return the node here or it could lead to false-positive mutation detection
+		if (stopped) return;
+		if (!node.type) return;
 
 		/** @type {T | void} */
 		let result;

--- a/test/transformation.js
+++ b/test/transformation.js
@@ -152,3 +152,14 @@ test('returns undefined if there are no child transformations', () => {
 
 	expect(result).toBe(undefined);
 });
+
+test('doesnt mutate tree with non-type objects', () => {
+	const tree = {
+		type: 'Root',
+		children: [{ type: 'A', metadata: { foo: true } }, { type: 'B' }]
+	};
+
+	const transformed = walk(tree, null, {});
+
+	expect(transformed).toBe(tree);
+});


### PR DESCRIPTION
The node was previously returned as-is in some cases. That resulted in a false-positive mutation detection further up the visitor chain.