### PR TITLE
fix: Keep non-enumerable properties

### DIFF
--- a/src/walk.js
+++ b/src/walk.js
@@ -75,7 +75,7 @@ export function walk(node, state, visitors) {
 				path.pop();
 
 				if (Object.keys(mutations).length > 0) {
-					return { ...node, ...mutations };
+					return merge_objects(node, mutations);
 				}
 			},
 			stop: () => {
@@ -122,7 +122,7 @@ export function walk(node, state, visitors) {
 
 		if (!result) {
 			if (Object.keys(mutations).length > 0) {
-				result = { ...node, ...mutations };
+				result = merge_objects(node, mutations);
 			}
 		}
 
@@ -132,4 +132,23 @@ export function walk(node, state, visitors) {
 	}
 
 	return visit(node, [], state) ?? node;
+}
+
+/**
+ * @template {Record<string, any>} T
+ * @param {T} a
+ * @param {Record<string, any>} b
+ * @returns {T}
+ */
+function merge_objects(a, b) {
+	const obj = /** @type {T} */ ({});
+	for (const key of Reflect.ownKeys(a)) {
+		// @ts-expect-error use ownKeys to preserve non-enumerable keys
+		obj[key] = a[key];
+	}
+	// For new properties we assume that noone uses non-enumerable keys
+	for (const key in b) {
+		obj[/** @type {keyof T} */ (key)] = b[key];
+	}
+	return obj;
 }

--- a/test/transformation.js
+++ b/test/transformation.js
@@ -152,3 +152,41 @@ test('returns undefined if there are no child transformations', () => {
 
 	expect(result).toBe(undefined);
 });
+
+test('keeps non-enumerable properties', () => {
+	/** @type {import('./types').TestNode} */
+	const tree = {
+		type: 'Root',
+		children: [
+			{
+				type: 'Root',
+				children: [{ type: 'A' }, { type: 'B' }]
+			},
+			{ type: 'B' }
+		]
+	};
+	Object.defineProperty(tree.children[0], 'metadata', {
+		value: { foo: true },
+		enumerable: false
+	});
+
+	const transformed = walk(
+		/** @type {import('./types').TestNode} */ (tree),
+		null,
+		{
+			A() {
+				return {
+					type: 'TransformedA'
+				};
+			}
+		}
+	);
+
+	expect(
+		/** @type {import('./types').Root} */ (transformed).children[0]
+	).toEqual({
+		type: 'Root',
+		metadata: { foo: true },
+		children: [{ type: 'TransformedA' }, { type: 'B' }]
+	});
+});

--- a/test/types.d.ts
+++ b/test/types.d.ts
@@ -1,10 +1,12 @@
 export interface Root {
 	type: 'Root';
 	children: TestNode[];
+	metadata?: any;
 }
 
 export interface A {
 	type: 'A';
+	metadata?: any;
 }
 
 export interface B {


### PR DESCRIPTION
When merging mutations into the original node, non-enumerable properties (like the parent property in Svelte's internal AST) got  lost. This PR uses `Reflect.ownKeys` to avoid that.