### PR TITLE
feat: Allow AST to be mutated via new option

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # zimmerframe changelog
 
+## 1.2.0
+
+- Allow AST to be mutated via new option ([#20](https://github.com/Rich-Harris/zimmerframe/pull/21))
+
 ## 1.1.2
 
 - Keep non-enumerable properties non-enumerable ([#20](https://github.com/Rich-Harris/zimmerframe/pull/20))

--- a/README.md
+++ b/README.md
@@ -131,7 +131,7 @@ Each visitor receives a second argument, `context`, which is an object with the 
 
 ## Immutability
 
-ASTs are regarded as immutable. If you return a transformed node from a visitor, then all parents of the node will be replaced with clones, but unchanged subtrees will reuse the existing nodes.
+By default ASTs are regarded as immutable. If you return a transformed node from a visitor, then all parents of the node will be replaced with clones, but unchanged subtrees will reuse the existing nodes.
 
 For example in this case, no transformation takes place, meaning that the returned value is identical to the original AST:
 
@@ -174,6 +174,8 @@ transformed.left === original.left; // true, we can safely reuse this node
 ```
 
 This makes it very easy to transform parts of your AST without incurring the performance and memory overhead of cloning the entire thing, and without the footgun of mutating it in place.
+
+In case you _do_ want to mutate everything in place, pass `{ mutate: true }` as the fourth parameter to `walk`.
 
 ## License
 

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
 	"name": "zimmerframe",
 	"description": "A tool for walking ASTs",
-	"version": "1.1.2",
+	"version": "1.2.0",
 	"repository": {
 		"type": "git",
 		"url": "https://github.com/Rich-Harris/zimmerframe"

--- a/src/walk.js
+++ b/src/walk.js
@@ -4,8 +4,10 @@
  * @param {T} node
  * @param {U} state
  * @param {import('./types').Visitors<T, U>} visitors
+ * @param {{ mutate?: boolean }} [options]
  */
-export function walk(node, state, visitors) {
+export function walk(node, state, visitors, options) {
+	const mutate = options?.mutate ?? false;
 	const universal = visitors._;
 
 	let stopped = false;
@@ -76,7 +78,11 @@ export function walk(node, state, visitors) {
 				path.pop();
 
 				if (Object.keys(mutations).length > 0) {
-					return apply_mutations(node, mutations);
+					if (mutate) {
+						mutate_node(node, mutations);
+					} else {
+						return apply_mutations(node, mutations);
+					}
 				}
 			},
 			stop: () => {
@@ -123,7 +129,11 @@ export function walk(node, state, visitors) {
 
 		if (!result) {
 			if (Object.keys(mutations).length > 0) {
-				result = apply_mutations(node, mutations);
+				if (mutate) {
+					mutate_node(node, mutations);
+				} else {
+					result = apply_mutations(node, mutations);
+				}
 			}
 		}
 
@@ -156,4 +166,14 @@ function apply_mutations(node, mutations) {
 	}
 
 	return /** @type {T} */ (obj);
+}
+
+/**
+ * @param {any} node
+ * @param {Record<string, any>} mutations
+ */
+function mutate_node(node, mutations) {
+	for (const key in mutations) {
+		node[key] = mutations[key];
+	}
 }

--- a/test/transformation.js
+++ b/test/transformation.js
@@ -201,3 +201,29 @@ test('doesnt mutate tree with non-type objects', () => {
 
 	expect(transformed).toBe(tree);
 });
+
+test('mutates tree if mutate is true', () => {
+	const original_c = { type: 'C', x: true };
+	const tree = {
+		type: 'Root',
+		children: [{ type: 'A', children: [original_c] }, { type: 'B' }]
+	};
+
+	const transformed = walk(
+		tree,
+		null,
+		{
+			C(node) {
+				return { ...node, x: false };
+			}
+		},
+		{ mutate: true }
+	);
+
+	// @ts-expect-error
+	const c = transformed.children[0].children[0];
+
+	expect(transformed).toBe(tree);
+	expect(c.x).toBe(false);
+	expect(c).not.toBe(original_c);
+});


### PR DESCRIPTION
This adds a fourth (optional) parameter to `walk`, through which you can tell it to mutate the AST in place rather than treating it as immutable.

This will help solve https://github.com/sveltejs/svelte/issues/14204: by stripping the TS AST nodes in a mutable way, the `parent` and `prev` nodes are kept intact (right now they point to the outdated originals). Theoretically that could also be achieved through walking the AST after detecting that a subtree was changed, but it's much more cumbersome/less performant, and the pragmatic solution is to make the AST mutable instead.