### PR TITLE
docs: fix typo in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -155,7 +155,7 @@ const original = {
     type: 'Identifier',
     name: 'foo'
   },
-  left: {
+  right: {
     type: 'Identifier',
     name: 'bar'
   }


### PR DESCRIPTION
The node name seems to be incorrect.