### PR TITLE
fix: optimize array traversal, clean up code

### DIFF
--- a/.changeset/proud-poems-laugh.md
+++ b/.changeset/proud-poems-laugh.md
@@ -1,0 +1,5 @@
+---
+'zimmerframe': patch
+---
+
+chore: speed up array traversal

--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
 	"devDependencies": {
 		"@changesets/cli": "^2.29.7",
 		"dts-buddy": "^0.1.13",
-		"typescript": "^5.1.6",
+		"typescript": "^5.9.2",
 		"vitest": "^0.34.2"
 	},
 	"scripts": {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -12,8 +12,8 @@ devDependencies:
     specifier: ^0.1.13
     version: 0.1.13
   typescript:
-    specifier: ^5.1.6
-    version: 5.1.6
+    specifier: ^5.9.2
+    version: 5.9.2
   vitest:
     specifier: ^0.34.2
     version: 0.34.2
@@ -705,8 +705,8 @@ packages:
       magic-string: 0.30.2
       sade: 1.8.1
       tiny-glob: 0.2.9
-      ts-api-utils: 0.0.46(typescript@5.1.6)
-      typescript: 5.1.6
+      ts-api-utils: 0.0.46(typescript@5.9.2)
+      typescript: 5.9.2
     dev: true
 
   /enquirer@2.4.1:
@@ -807,8 +807,8 @@ packages:
       universalify: 0.1.2
     dev: true
 
-  /fsevents@2.3.2:
-    resolution: {integrity: sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==}
+  /fsevents@2.3.3:
+    resolution: {integrity: sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==}
     engines: {node: ^8.16.0 || ^10.6.0 || >=11.0.0}
     os: [darwin]
     requiresBuild: true
@@ -1151,7 +1151,7 @@ packages:
     engines: {node: '>=14.18.0', npm: '>=8.0.0'}
     hasBin: true
     optionalDependencies:
-      fsevents: 2.3.2
+      fsevents: 2.3.3
     dev: true
 
   /run-parallel@1.2.0:
@@ -1278,13 +1278,13 @@ packages:
       is-number: 7.0.0
     dev: true
 
-  /ts-api-utils@0.0.46(typescript@5.1.6):
+  /ts-api-utils@0.0.46(typescript@5.9.2):
     resolution: {integrity: sha512-YKJeSx39n0mMk+hrpyHKyTgxA3s7Pz/j1cXYR+t8HcwwZupzOR5xDGKnOEw3gmLaUeFUQt3FJD39AH9Ajn/mdA==}
     engines: {node: '>=16.13.0'}
     peerDependencies:
       typescript: '>=4.2.0'
     dependencies:
-      typescript: 5.1.6
+      typescript: 5.9.2
     dev: true
 
   /type-detect@4.0.8:
@@ -1292,8 +1292,8 @@ packages:
     engines: {node: '>=4'}
     dev: true
 
-  /typescript@5.1.6:
-    resolution: {integrity: sha512-zaWCozRZ6DLEWAWFrVDz1H6FVXzUSfTy5FUMWsQlU8Ym5JP9eO4xkTIROFCQvhQf61z6O/G6ugw3SgAnvvm+HA==}
+  /typescript@5.9.2:
+    resolution: {integrity: sha512-CWBzXQrc/qOkhidw1OzBTQuYRbfyxDXJMVJ1XNwUHGROVmuaeiEm3OslpZ1RV96d7SKKjZKrSJu3+t/xlw3R9A==}
     engines: {node: '>=14.17'}
     hasBin: true
     dev: true
@@ -1362,7 +1362,7 @@ packages:
       postcss: 8.4.28
       rollup: 3.28.0
     optionalDependencies:
-      fsevents: 2.3.2
+      fsevents: 2.3.3
     dev: true
 
   /vitest@0.34.2:

--- a/src/walk.js
+++ b/src/walk.js
@@ -48,20 +48,22 @@ export function walk(node, state, visitors) {
 						if (Array.isArray(child_node)) {
 							/** @type {Record<number, T>} */
 							const array_mutations = {};
-							let mutated = 0;
 							const len = child_node.length;
+
+							let mutated = false;
+
 							for (let i = 0; i < len; i++) {
 								const node = child_node[i];
 								if (node && typeof node === 'object') {
 									const result = visit(node, path, next_state);
 									if (result) {
 										array_mutations[i] = result;
-										mutated++;
+										mutated = true;
 									}
 								}
 							}
 
-							if (mutated > 0) {
+							if (mutated) {
 								mutations[key] = child_node.map(
 									(node, i) => array_mutations[i] ?? node
 								);

--- a/src/walk.js
+++ b/src/walk.js
@@ -1,16 +1,18 @@
+/** @import { Context, Visitor, Visitors } from './types.js' */
+
 /**
- * @template {{type: string}} T
+ * @template {{ type: string }} T
  * @template {Record<string, any> | null} U
  * @param {T} node
  * @param {U} state
- * @param {import('./types').Visitors<T, U>} visitors
+ * @param {Visitors<T, U>} visitors
  */
 export function walk(node, state, visitors) {
 	const universal = visitors._;
 
 	let stopped = false;
 
-	/** @type {import('./types').Visitor<T, U, T>} _ */
+	/** @type {Visitor<T, U, T>} _ */
 	function default_visitor(_, { next, state }) {
 		next(state);
 	}
@@ -32,7 +34,7 @@ export function walk(node, state, visitors) {
 		/** @type {Record<string, any>} */
 		const mutations = {};
 
-		/** @type {import('./types').Context<T, U>} */
+		/** @type {Context<T, U>} */
 		const context = {
 			path,
 			state,
@@ -46,15 +48,20 @@ export function walk(node, state, visitors) {
 						if (Array.isArray(child_node)) {
 							/** @type {Record<number, T>} */
 							const array_mutations = {};
-
-							child_node.forEach((node, i) => {
+							let mutated = 0;
+							const len = child_node.length;
+							for (let i = 0; i < len; i++) {
+								const node = child_node[i];
 								if (node && typeof node === 'object') {
 									const result = visit(node, path, next_state);
-									if (result) array_mutations[i] = result;
+									if (result) {
+										array_mutations[i] = result;
+										mutated++;
+									}
 								}
-							});
+							}
 
-							if (Object.keys(array_mutations).length > 0) {
+							if (mutated > 0) {
 								mutations[key] = child_node.map(
 									(node, i) => array_mutations[i] ?? node
 								);
@@ -90,7 +97,7 @@ export function walk(node, state, visitors) {
 			}
 		};
 
-		let visitor = /** @type {import('./types').Visitor<T, U, T>} */ (
+		let visitor = /** @type {Visitor<T, U, T>} */ (
 			visitors[/** @type {T['type']} */ (node.type)] ?? default_visitor
 		);
 


### PR DESCRIPTION
While profiling a project of mine that uses zimmerframe, I noticed that most deopts came from traversing arrays in `walk`, so I optimized some code here. I also cleaned up some of the code. 