### PR TITLE
chore: add default entry to exports field

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,7 +10,8 @@
 	"exports": {
 		".": {
 			"types": "./types/index.d.ts",
-			"import": "./src/walk.js"
+			"import": "./src/walk.js",
+			"default": "./src/walk.js"
 		}
 	},
 	"types": "./types/index.d.ts",


### PR DESCRIPTION
This increases compatibility. For additional context: I have a ESM project which imports CJS lib that imports this package and I'm getting `No "exports" main defined in <path>\node_modules\zimmerframe\package.json` error. 

Workaround is, instead of using normal import to use `import()` function but adding `default` to this package makes everything just work.